### PR TITLE
Fix license in netkan

### DIFF
--- a/SaturableRW.netkan
+++ b/SaturableRW.netkan
@@ -6,8 +6,7 @@
     "name"           : "Semi-Saturable Reaction Wheels",
     "identifier"     : "SaturableRW",
     "abstract"       : "Saturable Reaction Wheels makes stock reaction wheels more realistic by adding momentum management.",
-	"author"     	 : ["PhineasFreak", "Crzyrndm"],
-    "license"        : "GNU",
+    "author"         : ["PhineasFreak", "Crzyrndm"],
     "release_status" : "stable",
     "install" : [
         {


### PR DESCRIPTION
KSP-CKAN/NetKAN#7163 is failing validation because "GNU" isn't a valid license.

As of KSP-CKAN/CKAN#2663, Netkan has the ability to get licenses from GitHub.

If you check the GitHub API page for this repo, the license is correctly detected and specified:

https://api.github.com/repos/PhineasFreak/SaturableRW

```json
  "license": {
    "key": "gpl-3.0",
    "name": "GNU General Public License v3.0",
    "spdx_id": "GPL-3.0",
    "url": "https://api.github.com/licenses/gpl-3.0",
    "node_id": "MDc6TGljZW5zZTk="
  },
```

So simply removing the license line will work.